### PR TITLE
Make Validator Class callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Added
 - `EachRule`
+- Made `Validator` a callable class
+
+### Deprecated
+- `Validator.build()`
 
 ### Changed
 - Moved all files to src folder. Use `import 'package:flrx_validator/validator.dart';` *BREAKING CHANGE*

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ TextFormField(
     validator: Validator<String>()
         .add(RequiredRule())
         .add(EmailRule())
-        .build()
 );
 
 ....

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,7 +11,6 @@ TextFormField(
     validator: Validator<String>()
         .add(RequiredRule())
         .add(EmailRule())
-        .build()
 );
 ```
 

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -17,7 +17,6 @@ This `Rule` validates if the input provided to it is not empty.
 ```dart
 Validator<String>()
     .add(RequiredRule())
-    .build()
 ```
 
 **Output**
@@ -33,7 +32,6 @@ This `Rule` validates if the input's length is less than the max limit.
 ```dart
 Validator<String>()
     .add(MaxLengthRule(20))
-    .build()
 ```
 
 **Output**
@@ -49,7 +47,6 @@ This `Rule` validates if the input's length is more than the min limit.
 ```dart
 Validator<String>()
     .add(MinLengthRule(6))
-    .build()
 ```
 
 **Output**
@@ -65,7 +62,6 @@ This `Rule` validates if the input matches a `RegEx` pattern.
 ```dart
 Validator<String>()
     .add(RegexRule(r"([(+]*[0-9]+[()+. -]*)"))
-    .build()
 ```
 
 **Output**
@@ -81,7 +77,6 @@ This `Rule` is an extension of `RegexRule` which checks the input against the em
 ```dart
 Validator<String>()
     .add(EmailRule())
-    .build()
 ```
 
 **Output**
@@ -97,7 +92,6 @@ This `Rule` checks whether the input provided is present in the the values provi
 ```dart
 Validator<String>()
     .add(OneOfRule(['value1', 'value2', 'value3']))
-    .build()
 ```
 
 **Output**
@@ -113,7 +107,6 @@ This `Rule` checks if the value provided is in the list of accepted values.
 ```dart
 Validator<String>()
     .add(InRule(['value1', 'value2', 'value3']))
-    .build()
 ```
 
 **Output**
@@ -129,7 +122,6 @@ This `Rule` checks if the value provided is not in the list of rejected values.
 ```dart
 Validator<String>()
     .add(NotInRule(['value1', 'value2', 'value3']))
-    .build()
 ```
 
 **Output**
@@ -145,7 +137,6 @@ This `Rule` checks whether the input provided passes any of the `Rule`s provided
 ```dart
 Validator<String>()
     .add(AnyRule([MinLengthRule(6), EmailRule()]))
-    .build()
 ```
 
 **Output**
@@ -168,7 +159,6 @@ Validator<String>()
         validationMessage: ":entity should contain one lowercase character",
       ),
     ]))
-    .build()
 ```
 
 **Output**
@@ -197,7 +187,6 @@ You can pass a custom message as follows
 ```dart
 Validator<String>()
     .add(RequiredRule(validationMessage:"Email is needed for creating an account"))
-    .build()
 ```
 
 **Output**

--- a/doc/validator.md
+++ b/doc/validator.md
@@ -15,12 +15,12 @@ The error message of the first `Rule` that fails is returned back. If all the `R
 
 There are two ways to run the validator.
 
-### Via `build()`
+### Through the instance
 
-The `Validator`'s `build()` method is useful if you want to add validation to a `FormField` Widget.
+The `Validator` instance itself can be passed to a `FormField` Widget if you want to add validation.
 
 ```dart
-TextFormField(validator: Validator<String>().build())
+TextFormField(validator: Validator<String>())
 ```
 
 
@@ -70,7 +70,6 @@ The `Validator` takes `Rule`s against which the value is validated. You can add 
 TextFormField(
     validator: Validator<String>()
         .add(RequiredRule())
-        .build()
 )
 ```
 
@@ -81,7 +80,6 @@ TextFormField(
     validator: Validator<String>()
         .add(RequiredRule())
         .add(EmailRule())
-        .build()
 )
 ```
 
@@ -93,7 +91,6 @@ If you have multiple `Rule`s to add and you do not want to chain the `add` metho
 TextFormField(
     validator: Validator<String>()
         .addAll([RequiredRule(), EmailRule()])
-        .build()
 )
 ```
 
@@ -109,7 +106,6 @@ The **`Validator`** runs the **`Rule`**'s in the order they are registered.
 TextFormField(
     validator: Validator<String>(entityName: 'Password')
         .add(MinLengthRule(6))
-        .build()
 )
 ```
 
@@ -135,7 +131,6 @@ TextFormField(
         transformMessage: (String message, Map<String, String> params) =>
             message.toUpperCase();
     ).add(RequiredRule())
-    .build()
 )
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -33,7 +33,7 @@ class _MaterialFormState extends State<MaterialForm> {
             children: <Widget>[
               TextFormField(
                 validator:
-                    Validator().add(RequiredRule()).add(EmailRule()).build(),
+                    Validator().add(RequiredRule()).add(EmailRule()),
                 decoration: InputDecoration(hintText: 'Email'),
               ),
               buildDropdown(),
@@ -53,7 +53,7 @@ class _MaterialFormState extends State<MaterialForm> {
 
   Widget buildDropdown() {
     return DropdownButtonFormField<String>(
-      validator: Validator().add(RequiredRule()).build(),
+      validator: Validator().add(RequiredRule()),
       value: "",
       items: <DropdownMenuItem<String>>[
         DropdownMenuItem<String>(

--- a/example/lib/material_form.dart
+++ b/example/lib/material_form.dart
@@ -23,10 +23,8 @@ class _MaterialFormState extends State<MaterialForm> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               TextFormField(
-                validator: Validator<String>()
-                    .add(RequiredRule())
-                    .add(EmailRule())
-                    .build(),
+                validator:
+                    Validator<String>().add(RequiredRule()).add(EmailRule()),
                 decoration: InputDecoration(hintText: 'Email'),
               ),
               TextFormField(
@@ -41,8 +39,7 @@ class _MaterialFormState extends State<MaterialForm> {
                               ":entity should contain one lowercase character",
                         ),
                       ],
-                    ))
-                    .build(),
+                    )),
                 decoration: InputDecoration(hintText: 'Password'),
                 obscureText: true,
               ),
@@ -63,7 +60,7 @@ class _MaterialFormState extends State<MaterialForm> {
 
   Widget buildDropdown() {
     return DropdownButtonFormField<String>(
-      validator: Validator<String>().add(RequiredRule()).build(),
+      validator: Validator<String>().add(RequiredRule()),
       value: "",
       items: const <DropdownMenuItem<String>>[
         DropdownMenuItem<String>(

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -40,10 +40,13 @@ class Validator<T> {
   }
 
   /// Returns a Function that can be called to validate. Added as a convenience for Flutter
+  @Deprecated('No need to call build anymore')
   String Function(T value) build() => validate;
 
+  String validate(T value) => call(value);
+
   /// Validates and returns an error message(if any).
-  String validate(T value) {
+  String call(T value) {
     String validationMessage;
     rulesList.any((Rule<T> rule) {
       rule.transformMessage ??= transformMessage;

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -43,10 +43,10 @@ class Validator<T> {
   @Deprecated('No need to call build anymore')
   String Function(T value) build() => validate;
 
-  String validate(T value) => call(value);
+  String call(T value) => validate(value);
 
   /// Validates and returns an error message(if any).
-  String call(T value) {
+  String validate(T value) {
     String validationMessage;
     rulesList.any((Rule<T> rule) {
       rule.transformMessage ??= transformMessage;

--- a/test/unit/validator/validator_test.dart
+++ b/test/unit/validator/validator_test.dart
@@ -12,6 +12,18 @@ void main() {
     mockRule = MockRule();
   });
 
+  group('Validator\'s legacy functions run as expected', () {
+    test('Validator\'s build method runs the validator', () {
+      Function validationFunction = validator.add(mockRule).build();
+      String validationMessage = validationFunction(null);
+      expect(validationMessage, null);
+    });
+    test('Validator\'s validate method runs the validator', () {
+      String validationMessage = validator.add(mockRule).validate(null);
+      expect(validationMessage, null);
+    });
+  });
+
   group('validator_rules_tests', () {
     test('test_validation_has_all_added_rules', () {
       validator.add(mockRule);
@@ -24,13 +36,13 @@ void main() {
     });
 
     test('test_validation_rule_passes', () {
-      Function validationFunction = validator.add(mockRule).build();
+      Function validationFunction = validator.add(mockRule);
       String validationMessage = validationFunction(null);
       expect(validationMessage, null);
     });
 
     test('test_validation_rule_fails', () {
-      Function validationFunction = validator.add(mockRule).build();
+      Function validationFunction = validator.add(mockRule);
       String validationMessage = validationFunction("Fail");
       expect(validationMessage, "Fail");
     });
@@ -43,7 +55,7 @@ void main() {
     test('test_validator_with_message_transformer', () {
       Validator<String> customValidator =
           Validator<String>(transformMessage: upperCaseTransformer);
-      Function validationFunction = customValidator.add(mockRule).build();
+      Function validationFunction = customValidator.add(mockRule);
       String validationMessage = validationFunction("value");
       expect(validationMessage, "VALUE");
     });
@@ -53,7 +65,7 @@ void main() {
           Validator<String>(transformMessage: upperCaseTransformer);
       mockRule.transformMessage =
           (String message, Map<String, String> params) => message.toLowerCase();
-      Function validationFunction = customValidator.add(mockRule).build();
+      Function validationFunction = customValidator.add(mockRule);
       String validationMessage = validationFunction("Value");
       expect(validationMessage, "value");
     });
@@ -70,7 +82,7 @@ void main() {
             expect(params['mockParam'], mockParamValue);
             return message.toUpperCase();
           });
-      Function validationFunction = customValidator.add(mockRule).build();
+      Function validationFunction = customValidator.add(mockRule);
       validationFunction(valueToValidate);
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes the Validator a callable class
<!--- Describe your changes in detail -->
This allows us to get rid of the `build()` method that we use specifically use for Flutter `FormField`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This allows us to write more concise code and reduce verbosity.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing test cases were updated to not call the `build()` method and additional tests were added to verify the behavior for the (now legacy) `build()` method

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
