### PR TITLE
Allow RequireRule to work with non String Data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [v0.5.0]
 
 ### Changed
+`MinLengthRule`, `MaxLengthRule` now supports List and Map
+`RequiredRule` now supports List, Map and other Data types. In case of other Data type, nullability of the value is tested
 Update Project Style,
 Migrate Example to AndroidX
 Update Docs Dependencies
@@ -48,6 +50,7 @@ Update Docs Dependencies
 
 Initial Release
 
+[v0.5.0]: https://github.com/flrx/validator/compare/v0.5.0...v0.4.0+2
 [v0.4.0+2]: https://github.com/flrx/validator/compare/v0.4.0+2...v0.3.0
 [v0.3.0]: https://github.com/flrx/validator/compare/v0.3.0...v0.2.0
 [v0.2.0]: https://github.com/flrx/validator/compare/v0.2.0...v0.1.0

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -13,6 +13,9 @@ Flrx Validator comes with lot of built-in rules:
 ### RequiredRule
 
 This `Rule` validates if the input provided to it is not empty.
+It explicitly supports String, Map and Iterable.
+It implicitly supports any type which has the length getter.
+For any other type, the nullability of the value is tested,
 
 ```dart
 Validator<String>(rules: [RequiredRule()])
@@ -27,6 +30,8 @@ Entity is required
 ### MaxLengthRule
 
 This `Rule` validates if the input's length is less than the max limit.
+It explicitly supports String, Map and Iterable.
+It implicitly supports any type which has the length getter.
 
 ```dart
 Validator<String>(rules: [MaxLengthRule(20)])
@@ -36,6 +41,12 @@ Validator<String>(rules: [MaxLengthRule(20)])
 
 ```
 Entity should be less than 20 characters
+```
+
+To use it with your custom types, initialize the rule with dynamic Type.
+
+```dart
+Validator<MyCustomType>(rules: [MaxLengthRule<dynamic>(20)])
 ```
 
 ### MinLengthRule
@@ -51,6 +62,7 @@ Validator<String>(rules: [MinLengthRule(6)])
 ```
 Entity should be more than 6 characters
 ```
+The supported types and usage are similar to `MaxLengthRule`
 
 ### RegexRule
 

--- a/doc/rule.md
+++ b/doc/rule.md
@@ -13,12 +13,12 @@ Flrx Validator comes with lot of built-in rules:
 ### RequiredRule
 
 This `Rule` validates if the input provided to it is not empty.
-It explicitly supports String, Map and Iterable.
-It implicitly supports any type which has the length getter.
-For any other type, the nullability of the value is tested,
+* It explicitly supports String, Map and Iterable.
+* It implicitly supports any type which has the length getter.
+* For any other type, the nullability of the value is tested,
 
 ```dart
-Validator<String>(rules: [RequiredRule()])
+ Validator<String>(rules: [RequiredRule()])
 ```
 
 **Output**
@@ -30,8 +30,8 @@ Entity is required
 ### MaxLengthRule
 
 This `Rule` validates if the input's length is less than the max limit.
-It explicitly supports String, Map and Iterable.
-It implicitly supports any type which has the length getter.
+* It explicitly supports String, Map and Iterable.
+* It implicitly supports any type which has the length getter.
 
 ```dart
 Validator<String>(rules: [MaxLengthRule(20)])

--- a/example/lib/material_form.dart
+++ b/example/lib/material_form.dart
@@ -1,5 +1,6 @@
 import 'package:flrx_validator/flrx_validator.dart';
 import 'package:flutter/material.dart';
+import 'package:multiselect_formfield/multiselect_formfield.dart';
 
 class MaterialForm extends StatefulWidget {
   MaterialForm({Key key}) : super(key: key);
@@ -10,6 +11,7 @@ class MaterialForm extends StatefulWidget {
 
 class _MaterialFormState extends State<MaterialForm> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  List<String> _myActivities;
 
   @override
   Widget build(BuildContext context) {
@@ -23,13 +25,14 @@ class _MaterialFormState extends State<MaterialForm> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
               TextFormField(
-                validator:
-                    Validator<String>().add(RequiredRule()).add(EmailRule()),
+                validator: Validator<String>()
+                    .add(RequiredRule<String>())
+                    .add(EmailRule()),
                 decoration: InputDecoration(hintText: 'Email'),
               ),
               TextFormField(
                 validator: Validator<String>()
-                    .add(RequiredRule())
+                    .add(RequiredRule<String>())
                     .add(EachRule<String>(
                       <Rule<String>>[
                         MinLengthRule(8),
@@ -43,7 +46,9 @@ class _MaterialFormState extends State<MaterialForm> {
                 decoration: InputDecoration(hintText: 'Password'),
                 obscureText: true,
               ),
-              buildDropdown(),
+              buildStringDropdown(),
+              buildIntDropdown(),
+              buildMultiSelectField(),
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 16.0),
                 child: RaisedButton(
@@ -58,9 +63,9 @@ class _MaterialFormState extends State<MaterialForm> {
     );
   }
 
-  Widget buildDropdown() {
+  Widget buildStringDropdown() {
     return DropdownButtonFormField<String>(
-      validator: Validator<String>().add(RequiredRule()),
+      validator: Validator<String>().add(RequiredRule<String>()),
       value: "",
       items: const <DropdownMenuItem<String>>[
         DropdownMenuItem<String>(
@@ -71,7 +76,30 @@ class _MaterialFormState extends State<MaterialForm> {
           child: Text('Item 1'),
           value: "Item 1",
         )
-      ], onChanged: (String value) {  },
+      ],
+      onChanged: (String value) {},
+    );
+  }
+
+  Widget buildIntDropdown() {
+    return DropdownButtonFormField<int>(
+      validator: Validator<int>().add(RequiredRule<int>()),
+      value: 1,
+      items: const <DropdownMenuItem<int>>[
+        DropdownMenuItem<int>(
+          child: Text('Please select an Item'),
+          value: null,
+        ),
+        DropdownMenuItem<int>(
+          child: Text('Item 1'),
+          value: 1,
+        ),
+        DropdownMenuItem<int>(
+          child: Text('Item 2'),
+          value: 2,
+        )
+      ],
+      onChanged: (int value) {},
     );
   }
 
@@ -79,5 +107,57 @@ class _MaterialFormState extends State<MaterialForm> {
     if (_formKey.currentState.validate()) {
       // Process data.
     }
+  }
+
+  Widget buildMultiSelectField() {
+    return MultiSelectFormField(
+      autovalidate: false,
+      titleText: 'My workouts',
+      validator: Validator<dynamic>(rules: <Rule<List<String>>>[
+        RequiredRule<List<String>>(),
+      ]),
+      dataSource: const <Map<String, String>>[
+        const <String, String>{
+          "display": "Running",
+          "value": "Running",
+        },
+        const <String, String>{
+          "display": "Climbing",
+          "value": "Climbing",
+        },
+        const <String, String>{
+          "display": "Walking",
+          "value": "Walking",
+        },
+        const <String, String>{
+          "display": "Swimming",
+          "value": "Swimming",
+        },
+        const <String, String>{
+          "display": "Soccer Practice",
+          "value": "Soccer Practice",
+        },
+        const <String, String>{
+          "display": "Baseball Practice",
+          "value": "Baseball Practice",
+        },
+        const <String, String>{
+          "display": "Football Practice",
+          "value": "Football Practice",
+        },
+      ],
+      textField: 'display',
+      valueField: 'value',
+      okButtonLabel: 'OK',
+      cancelButtonLabel: 'CANCEL',
+      // required: true,
+      hintText: 'Please choose one or more',
+      initialValue: _myActivities,
+      onSaved: (value) {
+        setState(() {
+          _myActivities = value;
+        });
+      },
+    );
   }
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,6 +17,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
+  multiselect_formfield: ^0.1.3
   flrx_validator:
     path: ../
   flutter:

--- a/lib/src/rules/max_length_rule.dart
+++ b/lib/src/rules/max_length_rule.dart
@@ -1,14 +1,16 @@
 import 'package:flrx_validator/src/rules/rule.dart';
 
 /// A [Rule] subclass validating if the length of input is less than [maxLength].
-class MaxLengthRule extends Rule<String> {
+class MaxLengthRule<T extends dynamic> extends Rule<T> {
   final int maxLength;
 
   MaxLengthRule(this.maxLength, {String validationMessage})
-      : super(validationMessage);
+      : assert(T is List || T is Map || T is String),
+        super(validationMessage);
+
 
   @override
-  String onValidate(String entityName, String value) {
+  String onValidate(String entityName, T value) {
     if (value.length <= maxLength) {
       return null;
     }

--- a/lib/src/rules/max_length_rule.dart
+++ b/lib/src/rules/max_length_rule.dart
@@ -5,7 +5,7 @@ class MaxLengthRule<T extends dynamic> extends Rule<T> {
   final int maxLength;
 
   MaxLengthRule(this.maxLength, {String validationMessage})
-      : assert(T is List || T is Map || T is String),
+      : assert(T == List || T == Map || T == String || T == dynamic),
         super(validationMessage);
 
 
@@ -15,7 +15,7 @@ class MaxLengthRule<T extends dynamic> extends Rule<T> {
       return null;
     }
     return validationMessage ??
-        ':entity should be less than :maxLength characters';
+        ':entity length should be less than :maxLength';
   }
 
   @override

--- a/lib/src/rules/max_length_rule.dart
+++ b/lib/src/rules/max_length_rule.dart
@@ -8,14 +8,12 @@ class MaxLengthRule<T extends dynamic> extends Rule<T> {
       : assert(T == List || T == Map || T == String || T == dynamic),
         super(validationMessage);
 
-
   @override
   String onValidate(String entityName, T value) {
     if (value.length <= maxLength) {
       return null;
     }
-    return validationMessage ??
-        ':entity length should be less than :maxLength';
+    return validationMessage ?? ':entity length should be less than :maxLength';
   }
 
   @override

--- a/lib/src/rules/min_length_rule.dart
+++ b/lib/src/rules/min_length_rule.dart
@@ -5,13 +5,13 @@ class MinLengthRule<T extends dynamic> extends Rule<T> {
   final int minLength;
 
   MinLengthRule(this.minLength, {String validationMessage})
-      : assert(T is List || T is Map || T is String),
+      : assert(T == List || T == Map || T == String || T == dynamic),
         super(validationMessage);
 
   @override
   String onValidate(String entityName, T value) {
     if (value.length < minLength) {
-      return ':entity should be more than :minLength characters';
+      return ':entity length should be more than :minLength';
     }
     return null;
   }

--- a/lib/src/rules/min_length_rule.dart
+++ b/lib/src/rules/min_length_rule.dart
@@ -1,14 +1,15 @@
 import 'package:flrx_validator/src/rules/rule.dart';
 
 /// A [Rule] subclass validating if the input length is more than [minLength].
-class MinLengthRule extends Rule<String> {
+class MinLengthRule<T extends dynamic> extends Rule<T> {
   final int minLength;
 
   MinLengthRule(this.minLength, {String validationMessage})
-      : super(validationMessage);
+      : assert(T is List || T is Map || T is String),
+        super(validationMessage);
 
   @override
-  String onValidate(String entityName, String value) {
+  String onValidate(String entityName, T value) {
     if (value.length < minLength) {
       return ':entity should be more than :minLength characters';
     }

--- a/lib/src/rules/required_rule.dart
+++ b/lib/src/rules/required_rule.dart
@@ -6,22 +6,18 @@ class RequiredRule<T> extends Rule<T> {
 
   @override
   String onValidate(String entityName, T value) {
-    if (value == null) {
+    if (value == null ||
+        isEmptyIterable(value) ||
+        isEmptyMap(value) ||
+        isEmptyString(value)) {
       return ':entity is required.';
     }
-
-    if (value is Iterable && value.isEmpty) {
-      return ':entity is required.';
-    }
-
-    if (value is Map && value.isEmpty) {
-      return ':entity is required.';
-    }
-
-    if (value is String && value.isEmpty) {
-      return ':entity is required.';
-    }
-
     return null;
   }
+
+  bool isEmptyString(value) => value is String && value.isEmpty;
+
+  bool isEmptyMap(value) => value is Map && value.isEmpty;
+
+  bool isEmptyIterable(value) => value is Iterable && value.isEmpty;
 }

--- a/lib/src/rules/required_rule.dart
+++ b/lib/src/rules/required_rule.dart
@@ -1,14 +1,23 @@
 import 'package:flrx_validator/src/rules/rule.dart';
 
 /// A [Rule] subclass validating if the input is notEmpty.
-class RequiredRule extends Rule<String> {
+class RequiredRule<T> extends Rule<T> {
   RequiredRule({String validationMessage}) : super(validationMessage);
 
   @override
-  String onValidate(String entityName, String value) {
-    if (value.isEmpty) {
+  String onValidate(String entityName, T value) {
+    if (value == null) {
       return ':entity is required.';
     }
+
+    if (value is Iterable && value.isEmpty) {
+      return ':entity is required.';
+    }
+
+    if (value is String && value.isEmpty) {
+      return ':entity is required.';
+    }
+
     return null;
   }
 }

--- a/lib/src/rules/required_rule.dart
+++ b/lib/src/rules/required_rule.dart
@@ -14,6 +14,10 @@ class RequiredRule<T> extends Rule<T> {
       return ':entity is required.';
     }
 
+    if (value is Map && value.isEmpty) {
+      return ':entity is required.';
+    }
+
     if (value is String && value.isEmpty) {
       return ':entity is required.';
     }

--- a/lib/src/rules/required_rule.dart
+++ b/lib/src/rules/required_rule.dart
@@ -1,6 +1,9 @@
 import 'package:flrx_validator/src/rules/rule.dart';
 
 /// A [Rule] subclass validating if the input is notEmpty.
+/// If the Value is null, this rule fails.
+/// If the value if of type String and if the String is empty, this rule fails.
+/// If the value if of type Iterable or Map and if the value is empty, this rule fails.
 class RequiredRule<T> extends Rule<T> {
   RequiredRule({String validationMessage}) : super(validationMessage);
 

--- a/test/unit/rules/each_rule_test.dart
+++ b/test/unit/rules/each_rule_test.dart
@@ -19,12 +19,12 @@ void main() {
     test('Runs all rules', () {
       var message = rule.validate('Password', '123');
       expect(message,
-          'Password should be more than 6 characters\nPassword should contain one lowercase character');
+          'Password length should be more than 6\nPassword should contain one lowercase character');
     });
 
     test('Validated message exists only for rule that fails', () {
       var message = rule.validate('Password', 'abcd');
-      expect(message, 'Password should be more than 6 characters');
+      expect(message, 'Password length should be more than 6');
     });
 
     test('Validated message is null when all rules pass', () {

--- a/test/unit/rules/max_length_rule_test.dart
+++ b/test/unit/rules/max_length_rule_test.dart
@@ -3,22 +3,91 @@ import 'package:flrx_validator/src/utils/string_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var entityName = 'maxLength';
-  var maxLength = 5;
-  var validString = '12345';
-  var invalidString = '12345678';
+  group('String Max Length Rule Test', () {
+    var entityName = 'maxLength';
+    var maxLength = 5;
+    var validString = '12345';
+    var invalidString = '123456';
 
-  var rule = MaxLengthRule(maxLength);
-  rule.transformMessage = StringUtils.replaceWithValues;
+    var rule = MaxLengthRule<String>(maxLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
 
-  test('valid_max_length_test', () {
-    var validationError = rule.validate(entityName, validString);
-    expect(validationError, null);
+    test('valid_max_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_max_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be less than $maxLength');
+    });
   });
 
-  test('invalid_max_length_test', () {
-    var validationError = rule.validate(entityName, invalidString);
-    expect(validationError,
-        '$entityName should be less than $maxLength characters');
+  group('List Max Length Rule Test', () {
+    var entityName = 'maxLength';
+    var maxLength = 2;
+    var validString = [1, 2];
+    var invalidString = [1, 2, 3, 4, 5];
+
+    var rule = MaxLengthRule<List>(maxLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_max_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_max_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be less than $maxLength');
+    });
+  });
+
+  group('Map Max Length Rule Test', () {
+    var entityName = 'maxLength';
+    var maxLength = 1;
+    var validString = {1: 2};
+    var invalidString = {1: 2, 3: 4, 5: 56};
+
+    var rule = MaxLengthRule<Map>(maxLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_max_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_max_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be less than $maxLength');
+    });
+  });
+
+  group('Dynamic Max Length Rule Test', () {
+    var entityName = 'maxLength';
+    var maxLength = 2;
+    var invalidString = '12345';
+    var validString = '12';
+
+    var rule = MaxLengthRule(maxLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_max_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_max_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be less than $maxLength');
+    });
+  });
+
+  test('Object Max Length Rule Test', () {
+    expect(() => MaxLengthRule<Object>(3), throwsA(const TypeMatcher<Error>()));
   });
 }

--- a/test/unit/rules/min_length_rule_test.dart
+++ b/test/unit/rules/min_length_rule_test.dart
@@ -3,22 +3,90 @@ import 'package:flrx_validator/src/utils/string_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var entityName = 'minLength';
-  var minLength = 5;
-  var validString = '12345';
-  var invalidString = '12';
+  group('String Min Length Rule Test', () {
+    var entityName = 'minLength';
+    var minLength = 5;
+    var validString = '12345';
+    var invalidString = '12';
 
-  var rule = MinLengthRule(minLength);
-  rule.transformMessage = StringUtils.replaceWithValues;
+    var rule = MinLengthRule<String>(minLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
 
-  test('valid_min_length_test', () {
-    var validationError = rule.validate(entityName, validString);
-    expect(validationError, null);
+    test('valid_min_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_min_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be more than $minLength');
+    });
+  });
+  group('List Min Length Rule Test', () {
+    var entityName = 'minLength';
+    var minLength = 5;
+    var validString = [1, 2, 3, 4, 5];
+    var invalidString = [1, 2];
+
+    var rule = MinLengthRule<List>(minLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_min_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_min_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be more than $minLength');
+    });
   });
 
-  test('invalid_min_length_test', () {
-    var validationError = rule.validate(entityName, invalidString);
-    expect(validationError,
-        '$entityName should be more than $minLength characters');
+  group('Map Min Length Rule Test', () {
+    var entityName = 'minLength';
+    var minLength = 3;
+    var validString = {1: 2, 3: 4, 5: 56};
+    var invalidString = {1: 2};
+
+    var rule = MinLengthRule<Map>(minLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_min_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_min_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be more than $minLength');
+    });
+  });
+
+  group('Dynamic Min Length Rule Test', () {
+    var entityName = 'minLength';
+    var minLength = 5;
+    var validString = '12345';
+    var invalidString = '12';
+
+    var rule = MinLengthRule(minLength);
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_min_length_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_min_length_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError,
+          '$entityName length should be more than $minLength');
+    });
+  });
+
+  test('Object Min Length Rule Test', () {
+    expect(() => MinLengthRule<Object>(3), throwsA(const TypeMatcher<Error>()));
   });
 }

--- a/test/unit/rules/min_length_rule_test.dart
+++ b/test/unit/rules/min_length_rule_test.dart
@@ -19,8 +19,8 @@ void main() {
 
     test('invalid_min_length_test', () {
       var validationError = rule.validate(entityName, invalidString);
-      expect(validationError,
-          '$entityName length should be more than $minLength');
+      expect(
+          validationError, '$entityName length should be more than $minLength');
     });
   });
   group('List Min Length Rule Test', () {
@@ -39,8 +39,8 @@ void main() {
 
     test('invalid_min_length_test', () {
       var validationError = rule.validate(entityName, invalidString);
-      expect(validationError,
-          '$entityName length should be more than $minLength');
+      expect(
+          validationError, '$entityName length should be more than $minLength');
     });
   });
 
@@ -60,8 +60,8 @@ void main() {
 
     test('invalid_min_length_test', () {
       var validationError = rule.validate(entityName, invalidString);
-      expect(validationError,
-          '$entityName length should be more than $minLength');
+      expect(
+          validationError, '$entityName length should be more than $minLength');
     });
   });
 
@@ -81,12 +81,12 @@ void main() {
 
     test('invalid_min_length_test', () {
       var validationError = rule.validate(entityName, invalidString);
-      expect(validationError,
-          '$entityName length should be more than $minLength');
+      expect(
+          validationError, '$entityName length should be more than $minLength');
     });
   });
 
   test('Object Min Length Rule Test', () {
-    expect(() => MinLengthRule<Object>(3), throwsA(const TypeMatcher<Error>()));
+    expect(() => MinLengthRule<Rule>(3), throwsA(isA<AssertionError>()));
   });
 }

--- a/test/unit/rules/required_rule_test.dart
+++ b/test/unit/rules/required_rule_test.dart
@@ -3,20 +3,78 @@ import 'package:flrx_validator/src/utils/string_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var entityName = 'required';
-  var validString = '12';
-  var invalidString = '';
+  group('String Required Rule Test', () {
+    var entityName = 'required';
+    var validString = '12';
+    var invalidString = '';
 
-  var rule = RequiredRule();
-  rule.transformMessage = StringUtils.replaceWithValues;
+    var rule = RequiredRule();
+    rule.transformMessage = StringUtils.replaceWithValues;
 
-  test('valid_require_rule_test', () {
-    var validationError = rule.validate(entityName, validString);
-    expect(validationError, null);
+    test('valid_require_rule_test', () {
+      var validationError = rule.validate(entityName, validString);
+      expect(validationError, null);
+    });
+
+    test('invalid_require_rule_test', () {
+      var validationError = rule.validate(entityName, invalidString);
+      expect(validationError, '$entityName is required.');
+    });
+  });
+  group('List Required Rule Test', () {
+    var entityName = 'required';
+    var validList = ['12'];
+    var invalidList = [];
+
+    var rule = RequiredRule<List>();
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_require_rule_test', () {
+      var validationError = rule.validate(entityName, validList);
+      expect(validationError, null);
+    });
+
+    test('invalid_require_rule_test', () {
+      var validationError = rule.validate(entityName, invalidList);
+      expect(validationError, '$entityName is required.');
+    });
   });
 
-  test('invalid_require_rule_test', () {
-    var validationError = rule.validate(entityName, invalidString);
-    expect(validationError, '$entityName is required.');
+  group('Map Required Rule Test', () {
+    var entityName = 'required';
+    var validMap = {'12': '24'};
+    var invalidMap = {};
+
+    var rule = RequiredRule<Map>();
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_require_rule_test', () {
+      var validationError = rule.validate(entityName, validMap);
+      expect(validationError, null);
+    });
+
+    test('invalid_require_rule_test', () {
+      var validationError = rule.validate(entityName, invalidMap);
+      expect(validationError, '$entityName is required.');
+    });
+  });
+
+  group('Object Required Rule Test', () {
+    var entityName = 'required';
+    var validObject = Object();
+    Object invalidObject;
+
+    var rule = RequiredRule<Object>();
+    rule.transformMessage = StringUtils.replaceWithValues;
+
+    test('valid_require_rule_test', () {
+      var validationError = rule.validate(entityName, validObject);
+      expect(validationError, null);
+    });
+
+    test('invalid_require_rule_test', () {
+      var validationError = rule.validate(entityName, invalidObject);
+      expect(validationError, '$entityName is required.');
+    });
   });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows RequiredRule to work with Non String Data Types
In case of String, check if value is not empty,
In case of Iterables, check if iterable is not empty,
In other cases, check if value is not null
 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#17 

## How Has This Been Tested?
Tests have been written to check MinLength, MaxLength, RequiredRule for String, Map, List, and Object Data Types.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
